### PR TITLE
Separate deps from biocbook build

### DIFF
--- a/.github/workflows/biocbook.yml
+++ b/.github/workflows/biocbook.yml
@@ -1,6 +1,7 @@
 name: biocbook
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - devel

--- a/.github/workflows/biocbook.yml
+++ b/.github/workflows/biocbook.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - devel
       - RELEASE_**
+    paths-ignore:
+      - 'deps.Dockerfile'
 
 jobs:
   build-push:
@@ -17,15 +19,16 @@ jobs:
     steps:
       
       - name: 🧾 Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: ⏳ Collect Workflow Telemetry
-        uses: runforesight/workflow-telemetry-action@v1
+        uses: catchpoint/workflow-telemetry-action@v2
 
       - name: 🐳 Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
+
       - name: 🐳 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
   
       - name: 📝 Get book info
         id: info
@@ -41,15 +44,15 @@ jobs:
           echo pkgversion=$(grep -m1 -E '^Version: +' DESCRIPTION | sed -E 's/.*: +//') >> "${GITHUB_ENV}"
 
       - name: 🔐 Log in to the Github Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ env.owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🏷 Get metadata for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ env.owner }}/${{ env.pkgname }}
           tags: |
@@ -57,18 +60,20 @@ jobs:
             ${{ env.pkgversion }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'devel') }}
 
-      - name: 📦 Install, build and check package in local Docker image
+      - name: 📦 Build and push book image
         id: docker
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
+          file: biocbook.Dockerfile
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             BIOC_VERSION=${{ github.ref_name }}
+            OWNER=${{ env.owner }}
 
       - name: 🚀 Push local Docker image to ghcr.io
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
@@ -99,13 +104,13 @@ jobs:
           clean: false 
 
       - name: 💾 Upload package bundle artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bundle
           path: ${{ env.bundle_path }}
 
       - name: 💾 Upload book artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: book
           path: ${{ env.book_path }}

--- a/.github/workflows/biocbook.yml
+++ b/.github/workflows/biocbook.yml
@@ -22,6 +22,17 @@ jobs:
       - name: 🧾 Checkout repository
         uses: actions/checkout@v4
 
+      - name: 🏷 Set Bioc version
+        run: |
+          branch="${{ github.ref_name }}"
+          if [[ "$branch" == "devel" || "$branch" =~ ^RELEASE_ ]]; then
+            # Remove everything after and including '-' if present
+            version=${branch%%-*}
+            echo "BIOC_VERSION=${version}" >> "${GITHUB_ENV}"
+          else
+            echo "BIOC_VERSION=devel" >> "${GITHUB_ENV}"
+          fi
+
       - name: ⏳ Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2
 
@@ -70,7 +81,7 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
-            BIOC_VERSION=${{ github.ref_name }}
+            BIOC_VERSION=${{ env.BIOC_VERSION }}
             OWNER=${{ env.owner }}
 
       - name: 🚀 Push local Docker image to ghcr.io
@@ -80,7 +91,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
-            BIOC_VERSION=${{ github.ref_name }}
+            BIOC_VERSION=${{ env.BIOC_VERSION }}
 
       - name: 📚 Recover pkg artifacts generated during build in local Docker container (pkg bundle and book) 
         env:

--- a/.github/workflows/biocbook.yml
+++ b/.github/workflows/biocbook.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - devel
+      - devel-*
       - RELEASE_**
     paths-ignore:
       - 'deps.Dockerfile'

--- a/.github/workflows/depbuild.yml
+++ b/.github/workflows/depbuild.yml
@@ -33,7 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ env.owner }}/deps
+          images: ghcr.io/${{ github.repository_owner }}/deps
           tags: |
             ${{ github.ref_name }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'devel') }}

--- a/.github/workflows/depbuild.yml
+++ b/.github/workflows/depbuild.yml
@@ -1,6 +1,7 @@
 name: dependencies
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - devel

--- a/.github/workflows/depbuild.yml
+++ b/.github/workflows/depbuild.yml
@@ -21,6 +21,17 @@ jobs:
       - name: 🧾 Checkout repository
         uses: actions/checkout@v4
 
+      - name: 🏷 Set Bioc version
+        run: |
+          branch="${{ github.ref_name }}"
+          if [[ "$branch" == "devel" || "$branch" =~ ^RELEASE_ ]]; then
+            # Remove everything after and including '-' if present
+            version=${branch%%-*}
+            echo "BIOC_VERSION=${version}" >> "${GITHUB_ENV}"
+          else
+            echo "BIOC_VERSION=devel" >> "${GITHUB_ENV}"
+          fi
+
       - name: ⏳ Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2
 
@@ -46,4 +57,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
-            BIOC_VERSION=${{ github.ref_name }}
+            BIOC_VERSION=${{ env.BIOC_VERSION }}

--- a/.github/workflows/depbuild.yml
+++ b/.github/workflows/depbuild.yml
@@ -1,0 +1,48 @@
+name: dependencies
+
+on:
+  push:
+    branches:
+      - devel
+      - RELEASE_**
+    paths:
+      - 'DESCRIPTION'
+      - 'deps.Dockerfile'
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    name: build-deps (${{ github.ref_name }})
+    permissions:
+      packages: write
+
+    steps:
+      - name: 🧾 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: ⏳ Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v2
+
+      - name: 🐳 Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: 🐳 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 🏷 Get metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ env.owner }}/deps
+          tags: |
+            ${{ github.ref_name }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'devel') }}
+
+      - name: 📦 Build and push dependencies image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deps.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            BIOC_VERSION=${{ github.ref_name }}

--- a/.github/workflows/depbuild.yml
+++ b/.github/workflows/depbuild.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - devel
+      - devel-*
       - RELEASE_**
     paths:
       - 'DESCRIPTION'

--- a/biocbook.Dockerfile
+++ b/biocbook.Dockerfile
@@ -1,0 +1,10 @@
+ARG BIOC_VERSION
+ARG OWNER
+FROM ghcr.io/${OWNER}/deps:${BIOC_VERSION} AS builder
+COPY . /opt/pkg
+WORKDIR /opt/pkg
+
+# Install book package and build book
+RUN R CMD INSTALL . && \
+    quarto install --quiet tinytex && \
+    R CMD build --keep-empty-dirs --no-resave-data .

--- a/deps.Dockerfile
+++ b/deps.Dockerfile
@@ -4,7 +4,3 @@ COPY . /opt/pkg
 
 # Install book package 
 RUN Rscript -e 'repos <- BiocManager::repositories() ; remotes::install_local(path = "/opt/pkg/", repos=repos, dependencies=TRUE, build_vignettes=FALSE, upgrade=TRUE) ; sessioninfo::session_info(installed.packages()[,"Package"], include_base = TRUE)'
-
-## Build/install using same approach than BBS
-RUN R CMD INSTALL /opt/pkg
-RUN quarto install --quiet tinytex && R CMD build --keep-empty-dirs --no-resave-data /opt/pkg


### PR DESCRIPTION
Still waiting on workflow to pass on my side, but thought I'd PR before it gets late.

Main changes:
- Updated versions for actions
- Separated a dependencies docker build triggered only by changes in DESCRIPTION or deps.Dockerfile, from the biocbook docker build which inherits that image. Both images will be pushed.
- Added manual trigger button (workflow_dispatch) from Actions tab in Github UI to make it easier to trigger without changes in the repo
- Version is extracted from branch, but you can add `-suffixes`, so `RELEASE_3_20-sandbox` would build with 3.20 container base
